### PR TITLE
Rainer: Fix markdown mistakes

### DIFF
--- a/exercise-1/exercise-1-correctme.md
+++ b/exercise-1/exercise-1-correctme.md
@@ -18,8 +18,7 @@ Compare the **specification** with this **document**, and fix the style errors.
 * [Markdown specification](https://daringfireball.net/projects/markdown/)
 * [CommonMark specification](https://commonmark.org/)
 
-Thanks   
---------
+## Thanks
 
 1. https://github.com/markdownlint/markdownlint for the inspiration
 2. [`markdown-it`](https://github.com/markdown-it/markdown-it) for the parser and interactive demo idea!

--- a/exercise-1/exercise-1-correctme.md
+++ b/exercise-1/exercise-1-correctme.md
@@ -9,6 +9,7 @@ This `document` contains all sorts of violations of the above [CommonMark](https
 Compare the **specification** with this **document**, and fix the style errors. 
 
 ## Resources
+
 * [`markdownlint` on GitHub](https://github.com/DavidAnson/markdownlint)
 * [`markdownlint` on npm](https://www.npmjs.com/package/markdownlint)
 * [Markdown specification](https://daringfireball.net/projects/markdown/)

--- a/exercise-1/exercise-1-correctme.md
+++ b/exercise-1/exercise-1-correctme.md
@@ -6,7 +6,7 @@
 
 This `document` contains all sorts of violations of the above [CommonMark](https://commonmark.org/) specification.
 
-Compare the **specification** with this **document**, and fix the style errors. 
+Compare the **specification** with this **document**, and fix the style errors.
 
 ## Resources
 

--- a/exercise-1/exercise-1-correctme.md
+++ b/exercise-1/exercise-1-correctme.md
@@ -2,7 +2,6 @@
 
 `markdownlint` is a [Node.js](https://nodejs.org/) style checker and lint tool for [Markdown](https://en.wikipedia.org/wiki/Markdown)/[CommonMark](https://commonmark.org/) files to automatically validate content, prevent rendering problems, and promote consistency.
 
-
 ## Instructions
 
 This `document` contains all sorts of violations of the above [CommonMark](https://commonmark.org/) specification.
@@ -10,7 +9,6 @@ This `document` contains all sorts of violations of the above [CommonMark](https
 ## Instructions
 
 Compare the **specification** with this **document**, and fix the style errors. 
-
 
 ## Resources
 * [`markdownlint` on GitHub](https://github.com/DavidAnson/markdownlint)

--- a/exercise-1/exercise-1-correctme.md
+++ b/exercise-1/exercise-1-correctme.md
@@ -3,23 +3,23 @@
 `markdownlint` is a [Node.js](https://nodejs.org/) style checker and lint tool for [Markdown](https://en.wikipedia.org/wiki/Markdown)/[CommonMark](https://commonmark.org/) files to automatically validate content, prevent rendering problems, and promote consistency.
 
 
-####  Instructions
+## Instructions
 
-This `document ` contains all sorts of violations of the above (CommonMark)[https://commonmark.org/] specification.
+This `document` contains all sorts of violations of the above [CommonMark](https://commonmark.org/) specification.
 
-#### Instructions
+## Instructions
 
-Compare the **specification** with this ** document **, and fix the style errors. 
+Compare the **specification** with this **document**, and fix the style errors. 
 
 
-# Resources
+## Resources
 * [`markdownlint` on GitHub](https://github.com/DavidAnson/markdownlint)
-* [ `markdownlint` on npm ](https://www.npmjs.com/package/markdownlint)
-+ [Markdown specification](https://daringfireball.net/projects/markdown/)
- *	(CommonMark specification)[https://commonmark.org/]
+* [`markdownlint` on npm](https://www.npmjs.com/package/markdownlint)
+* [Markdown specification](https://daringfireball.net/projects/markdown/)
+* [CommonMark specification](https://commonmark.org/)
 
 Thanks   
 --------
 
 1. https://github.com/markdownlint/markdownlint for the inspiration 
-1. [`markdown-it`](https://github.com/markdown-it/markdown-it) for the parser and interactive demo idea!
+2. [`markdown-it`](https://github.com/markdown-it/markdown-it) for the parser and interactive demo idea!

--- a/exercise-1/exercise-1-correctme.md
+++ b/exercise-1/exercise-1-correctme.md
@@ -17,5 +17,5 @@ Compare the **specification** with this **document**, and fix the style errors.
 
 ## Thanks
 
-1. https://github.com/markdownlint/markdownlint for the inspiration
+1. [https://github.com/markdownlint/markdownlint](https://github.com/markdownlint/markdownlint) for the inspiration
 2. [`markdown-it`](https://github.com/markdown-it/markdown-it) for the parser and interactive demo idea!

--- a/exercise-1/exercise-1-correctme.md
+++ b/exercise-1/exercise-1-correctme.md
@@ -21,5 +21,5 @@ Compare the **specification** with this **document**, and fix the style errors.
 Thanks   
 --------
 
-1. https://github.com/markdownlint/markdownlint for the inspiration 
+1. https://github.com/markdownlint/markdownlint for the inspiration
 2. [`markdown-it`](https://github.com/markdown-it/markdown-it) for the parser and interactive demo idea!

--- a/exercise-1/exercise-1-correctme.md
+++ b/exercise-1/exercise-1-correctme.md
@@ -6,8 +6,6 @@
 
 This `document` contains all sorts of violations of the above [CommonMark](https://commonmark.org/) specification.
 
-## Instructions
-
 Compare the **specification** with this **document**, and fix the style errors. 
 
 ## Resources

--- a/exercise-1/exercise-1-correctme.md
+++ b/exercise-1/exercise-1-correctme.md
@@ -1,4 +1,4 @@
-## Introduction
+# Introduction
 
 `markdownlint` is a [Node.js](https://nodejs.org/) style checker and lint tool for [Markdown](https://en.wikipedia.org/wiki/Markdown)/[CommonMark](https://commonmark.org/) files to automatically validate content, prevent rendering problems, and promote consistency.
 

--- a/exercise-1/exercise-1-readme.md
+++ b/exercise-1/exercise-1-readme.md
@@ -27,12 +27,12 @@
 ## `.md`
 
 * `.md` steht für Markdown, und ist ein kleines Set von sowohl maschinen- wie auch menschenlesbaren Zeichenketten, mit denen Sie angeben können, wie Sie Ihren Text dargestellt haben möchten.
-* Es erfreut sich, auch dank github.com, aber vorallem aufgrund seiner Einfachheit, großer Beliebtheit bei Software-Projekten für die Dokumentation. 
+* Es erfreut sich, auch dank github.com, aber vorallem aufgrund seiner Einfachheit, großer Beliebtheit bei Software-Projekten für die Dokumentation.
 * Wenn Sie die [Basic Syntax](https://commonmark.org/help/) können, sind Sie bereits dabei.
 
 ## exercise-1
 
-1. Create an account on [github.com](https://github.com/) if you don't have one already. You can use your personal, your university or a [burner](https://temp-mail.org/en/) email. 
+1. Create an account on [github.com](https://github.com/) if you don't have one already. You can use your personal, your university or a [burner](https://temp-mail.org/en/) email.
 2. Find the [course repository](https://github.com/Aequivinius/uibk-python), and `fork` it. It might also make sense to `watch` it, if you want to receive notification if something changes. However, this is not strictly necessary, since the individual exercises will not change while you work on them.
 3. In your forked repository, which should be under `yourname/uibk-python`, locate the file `exercise-1/exercise-1-correctme.md` and edit it in the browser. There are some `.md` errors in this file, try to find them and save your changes in a first `commit`.
 4. Now, suggest your changes be added to the course repository by creating a `pull request`. This will trigger an action, in this case, a `.md` linter. Most likely, your first `pull request` will fail the linting, because the linter is quite strict. In this case, cancel the `pull request`. Check out the error messages, and fix the errors, `commit` and create a new `pull request` until you get a green checkmark.


### PR DESCRIPTION
- Fix links by switching square brackets and parenthesis.
- Remove redundant spaces.
- Set headings to same level.
- Fix list numbers.
- Remove spaces to make correct section bold.